### PR TITLE
Feat/weather api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,4 +47,4 @@ gem 'listen', group: :development
 
 gem 'dotenv-rails', group: [:development]
 
-gem 'httpclient'
+gem 'faraday', '1.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,5 @@ gem 'bootsnap', require: false
 gem 'listen', group: :development
 
 gem 'dotenv-rails', group: [:development]
+
+gem 'httpclient'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
@@ -199,6 +200,7 @@ DEPENDENCIES
   bootsnap
   coffee-rails
   dotenv-rails
+  httpclient
   jbuilder
   jquery-rails
   line-bot-api

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,14 @@ GEM
       railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.7.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
@@ -101,6 +105,7 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.3.3)
+    multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.7)
@@ -200,7 +205,7 @@ DEPENDENCIES
   bootsnap
   coffee-rails
   dotenv-rails
-  httpclient
+  faraday (= 1.3.0)
   jbuilder
   jquery-rails
   line-bot-api

--- a/app/exceptions/too_many_requests_exception.rb
+++ b/app/exceptions/too_many_requests_exception.rb
@@ -1,0 +1,5 @@
+module API
+  class TooManyRequestsException < StandardError
+
+  end
+end

--- a/app/models/api/open_weather_map/client.rb
+++ b/app/models/api/open_weather_map/client.rb
@@ -6,6 +6,7 @@ module API
       def initialize
         @connection = Faraday.new(url: BASE_URL) do |faraday|
           faraday.response :raise_error
+          faraday.options[:timeout] = 5
         end
       end
 

--- a/app/models/api/open_weather_map/client.rb
+++ b/app/models/api/open_weather_map/client.rb
@@ -1,17 +1,21 @@
 module API
   module OpenWeatherMap
     class Client
-      FORECAST_ENDPOINT = "https://api.openweathermap.org/data/2.5/forecast"
+      BASE_URL = "https://api.openweathermap.org"
+
+      def initialize
+        @connection = Faraday.new(url: BASE_URL) do |faraday|
+          faraday.response :raise_error
+        end
+      end
 
       # @return [Array<HourlyWeather>] 5日間分の3時間ごとの天気予報
       def fetch_three_hourly_forecasts(location = "tokyo")
-        client = HTTPClient.new
-        response = client.get(FORECAST_ENDPOINT, {
+        response = @connection.get("/data/2.5/forecast", {
           q: location,
           appid: ENV["OPEN_WEATHER_MAP_API_KEY"],
           units: "metric"
         })
-
         response_json = JSON.parse(response.body)
         forecasts = response_json["list"].map { |forecast| HourlyWeather.from_json(forecast) }
         return forecasts

--- a/app/models/api/open_weather_map/client.rb
+++ b/app/models/api/open_weather_map/client.rb
@@ -1,0 +1,21 @@
+module API
+  module OpenWeatherMap
+    class Client
+      FORECAST_ENDPOINT = "https://api.openweathermap.org/data/2.5/forecast"
+
+      # @return [Array<HourlyWeather>] 5日間分の3時間ごとの天気予報
+      def fetch_three_hourly_forecasts(location = "tokyo")
+        client = HTTPClient.new
+        response = client.get(FORECAST_ENDPOINT, {
+          q: location,
+          appid: ENV["OPEN_WEATHER_MAP_API_KEY"],
+          units: "metric"
+        })
+
+        response_json = JSON.parse(response.body)
+        forecasts = response_json["list"].map { |forecast| HourlyWeather.from_json(forecast) }
+        return forecasts
+      end
+    end
+  end
+end

--- a/app/models/api/open_weather_map/client.rb
+++ b/app/models/api/open_weather_map/client.rb
@@ -9,12 +9,14 @@ module API
         end
       end
 
-      # @return [Array<HourlyWeather>] 5日間分の3時間ごとの天気予報
+      # @return [Array<HourlyWeather>] 3時間ごとの12時間分の天気予報
       def fetch_three_hourly_forecasts(location = "tokyo")
         response = @connection.get("/data/2.5/forecast", {
           q: location,
           appid: ENV["OPEN_WEATHER_MAP_API_KEY"],
-          units: "metric"
+          units: "metric",
+          lang: "ja",
+          cnt: 4 # 12時間分の天気予報を取得する
         })
         response_json = JSON.parse(response.body)
         forecasts = response_json["list"].map { |forecast| HourlyWeather.from_json(forecast) }

--- a/app/models/api/open_weather_map/hourly_weather.rb
+++ b/app/models/api/open_weather_map/hourly_weather.rb
@@ -1,0 +1,23 @@
+module API
+  module OpenWeatherMap
+    class HourlyWeather
+      attr_reader :time
+      attr_reader :temperature
+      attr_reader :weather
+
+      def initialize(time:, temperature:, weather:)
+        @time = time
+        @temperature = temperature
+        @weather = weather
+      end
+
+      def self.from_json(json)
+        HourlyWeather.new(
+          time: Time.at(json["dt"]),
+          temperature: json["main"]["temp"],
+          weather: json["weather"][0]["main"]
+        )
+      end
+    end
+  end
+end

--- a/app/models/api/open_weather_map/hourly_weather.rb
+++ b/app/models/api/open_weather_map/hourly_weather.rb
@@ -1,19 +1,17 @@
 module API
   module OpenWeatherMap
     class HourlyWeather
-      attr_reader :time
-      attr_reader :temperature
-      attr_reader :weather
+      attr_reader :time_unix, :temperature, :weather
 
-      def initialize(time:, temperature:, weather:)
-        @time = time
+      def initialize(time_unix:, temperature:, weather:)
+        @time_unix = time_unix
         @temperature = temperature
         @weather = weather
       end
 
       def self.from_json(json)
         HourlyWeather.new(
-          time: Time.at(json["dt"]),
+          time_unix: json["dt"],
           temperature: json["main"]["temp"],
           weather: json["weather"][0]["main"]
         )


### PR DESCRIPTION
## 実装の背景・目的

利用者が「今日の天気は？」と質問したときに、その日の天気予報と、
天気に応じた運動をすることを促す機能を実装するために、
天気予報のAPIクライアントの実装を行った。

## やったこと

- Open Weather Mapの３時間毎/12時間分の天気予報を取得するAPIクライアントを作成
  - 利用しているAPI: [5 day weather forecast](./https://openweathermap.org/forecast5)
  - 「今日の天気」を知りたいので、12時間分のみを取得している。

## 補足

- [ ] 天気に応じて、提案する運動を考える。
- [ ] Open Weather Mapでは大まかに6種類の天気に分類されるので、どこまで対応するかを決める。
