### PR TITLE
Feat/wakeup early days

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,37 @@ class User < ApplicationRecord
     last_wakeup_date = last_wakeup.wakeup_at.to_date
     last_wakeup_date === Time.now.to_date
   end
+
+  # 連続して何日早起きできたか
+  def wakeup_early_days
+    wakeups_order_by_date = wakeups.order(wakeup_at: :desc)
+
+    prev_day = Time.now
+    days = 0
+    wakeups_order_by_date.each_with_index do |wakeup, i|
+      # 前の日との間隔が１日以上空いていたら、カウントを終了する
+      diff_in_sec = prev_day - wakeup.wakeup_at
+      diff_in_day = diff_in_sec / (60 * 60 * 24)
+      if diff_in_day > 1.0
+        prev_day = wakeup.wakeup_at
+        break
+      end
+
+      # 今日の朝の場合は、連続した日数としてカウントする
+      if i == 0 and wakeup.early?
+        days += 1
+        prev_day = wakeup.wakeup_at
+        next
+      end
+
+      # 別日の場合は、連続した日数としてカウントする（同じ日の場合は無視する）
+      if diff_in_day.to_i == 1 and wakeup.early?
+        days += 1
+      end
+
+      prev_day = wakeup.wakeup_at
+    end
+
+    days
+  end
 end

--- a/app/models/wakeup.rb
+++ b/app/models/wakeup.rb
@@ -1,3 +1,8 @@
 class Wakeup < ApplicationRecord
   belongs_to :user
+
+  # 早起きかどうか
+  def early?
+    wakeup_at.hour.between?(4, 7)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,7 +9,7 @@ class UserTest < ActiveSupport::TestCase
 
     # 昨日の起床時間を記録
     yesterday = Time.now.yesterday
-    user.save_wakeup(yesterday)
+    user.wakeups.create!(wakeup_at: yesterday)
     assert_not user.today_wakeup_saved?
 
     # 今日の起床時間を記録
@@ -17,4 +17,47 @@ class UserTest < ActiveSupport::TestCase
     user.save_wakeup(now)
     assert user.today_wakeup_saved?
   end
+
+  test "wakeup_early_days" do
+    user = User.create
+
+    today_morning = Time.now.change(hour: 7)
+    user.wakeups.create!(wakeup_at: today_morning)
+
+    # 同じ日に２回記録されていても、無視する
+    today_morning = Time.now.change(hour: 6)
+    user.wakeups.create!(wakeup_at: today_morning)
+
+    yesterday_morning = today_morning.ago(1.days)
+    user.wakeups.create!(wakeup_at: yesterday_morning)
+
+    assert_equal 2, user.wakeup_early_days
+  end
+
+  test "wakeup_early_day_with_not_continuous_days" do
+    user = User.create
+
+    today_morning = Time.now.change(hour: 7)
+    user.wakeups.create!(wakeup_at: today_morning)
+
+    # 連続して早起きできていなければ、カウントしない
+    user.wakeups.create!(wakeup_at: today_morning.ago(2.days))
+
+    assert_equal 1, user.wakeup_early_days
+  end
+
+  test "wakeup_early_day_with_not_early" do
+    user = User.create
+
+    today_morning = Time.now.change(hour: 7)
+    user.wakeups.create!(wakeup_at: today_morning)
+
+    # 連続した日付でも、早起きできていなければカウントしない
+    today_afternoon = today_morning.change(hour: 12)
+    yesterday_afternoon = today_afternoon.ago(1.days)
+    user.wakeups.create!(wakeup_at: yesterday_afternoon)
+
+    assert_equal 1, user.wakeup_early_days
+  end
+
 end


### PR DESCRIPTION
## 実装の背景・目的

利用者が「おはよう」と言ったときに、連続して早起きできていた時には、
それを褒める機能を実装した。
利用者が毎日早起きできることを後押しするために機能を追加した。

## やったこと

- 連続して何日早起きできたかを確認する機能を追加
- 「おはよう」と挨拶されたときに、１日以上早起きができていた場合には、利用者を褒めるメッセージを送信する。

## キャプチャ

![スクリーンショット 2021-11-19 19 52 39](https://user-images.githubusercontent.com/55840281/142611018-9ffa64c2-500d-47ab-b2e6-716725e88b7e.png)
## 補足

- 日数に応じて、スタンプラリーのような画像を表示する機能を付けていきたいです！
